### PR TITLE
Add /health endpoint

### DIFF
--- a/api/apps/api/urls.py
+++ b/api/apps/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from api.apps.api import views
 
 urlpatterns = [
+    url(r'^health$', views.Health.as_view()),
     url(r'^places/(?P<latlong>[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?))$',
         views.PlaceList.as_view()),
     url(r'^place/(?P<pid>[0-9a-zA-Z\-]+)/$', views.PlaceDetails.as_view()),

--- a/api/apps/api/views.py
+++ b/api/apps/api/views.py
@@ -1,10 +1,21 @@
 """Define the API views."""
 import os
 
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.apps.api.collectors import CollectorClient
+
+
+class Health(APIView):
+    """Health check endpoint."""
+
+    # pylint: disable=redefined-builtin,unused-argument
+    def get(self, request):
+        """Return the status of the application."""
+        content = {'status': 'ok'}
+        return Response(content, status=status.HTTP_200_OK)
 
 
 class PlaceList(APIView):

--- a/tools/kubernetes-django-env-vars.sh
+++ b/tools/kubernetes-django-env-vars.sh
@@ -5,7 +5,7 @@ NAMESPACE=default
 MINIKUBE_IP=$(minikube ip)
 
 # PostgreSQL
-PG_RELEASE=postgresql-postgresql
+PG_RELEASE=postgresql
 PG_POD_NAME=$(kubectl get pods --namespace ${NAMESPACE} -l "app=${PG_RELEASE}" -o jsonpath="{.items[0].metadata.name}")
 PG_USER=$(kubectl get po ${PG_POD_NAME} -o jsonpath="{.spec.containers[*].env[?(@.name=='PGUSER')].value}")
 PG_PASSWORD=$(kubectl get secret --namespace ${NAMESPACE} ${PG_RELEASE} -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
@@ -14,10 +14,10 @@ PG_PORT=$(minikube service ${PG_RELEASE} --url | awk -F/ '{print $3}' | awk -F: 
 PG_URL="postgres://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/postgres"
 
 # Redis
-REDIS_RELEASE=redis-redis
+REDIS_RELEASE=redis
 REDIS_POD_NAME=$(kubectl get pods --namespace ${NAMESPACE} -l "app=${REDIS_RELEASE}" -o jsonpath="{.items[0].metadata.name}")
 REDIS_HOST=${MINIKUBE_IP}
-REDIS_PORT=$(minikube service ${REDIS_RELEASE} --url | awk -F/ '{print $3}' | awk -F: '{print $2}')
+REDIS_PORT=$(minikube service ${REDIS_RELEASE}-master --url | awk -F/ '{print $3}' | awk -F: '{print $2}')
 REDIS_URL="redis://${REDIS_HOST}:${REDIS_PORT}"
 
 # Export all generated env vars.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Description
-----------
<!--- Describe your changes in detail -->
Adds a `/health` endpoint to check the health of the api.

Drive-by:
* Fix django-env-vars script
  Adjusts the script to handle the clustered redis chart.

Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kubernetes on the GKE requires an endpoint to check the health of the application.

How Has This Been Tested?
-------------------------
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, running curl against the local development server.

Types of changes
----------------
<!--- What types of changes does your code introduce? Remove what does not apply. -->
- New feature (non-breaking change which adds functionality)

Checklist
---------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have written unit tests.
- [] I have updated the documentation accordingly.

<!-- Place the *FULL* URL of the issue here it this PR fixes an existing issue. -->