### PR TITLE
Fix production settings

### DIFF
--- a/api/settings/production.py
+++ b/api/settings/production.py
@@ -8,7 +8,7 @@ DEBUG = False
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 # Get tbe production secret from the environment variables.
-SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"].strip()
 
 # Get tbe production allowed hosts from the environment variables, or limit it to localhost only.
-ALLOWED_HOSTS = os.environ['DJANGO_ALLOWED_HOSTS'].split(',')
+ALLOWED_HOSTS = os.environ['DJANGO_ALLOWED_HOSTS'].strip().split(',')

--- a/charts/values.prod.yaml
+++ b/charts/values.prod.yaml
@@ -18,5 +18,3 @@ persistence:
 
 service:
   type: ClusterIP
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: api.requestyoracks.org.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Description
-----------
<!--- Describe your changes in detail -->
Some environment variables end with a carriage return symbol ('\n'),
causing the Django production settings to be parsed incorrectly. This
patch strips such characters when reading environment variables.

Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix production....

How Has This Been Tested?
-------------------------
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the production settings in a developer envioronment (minikukbe).

Types of changes
----------------
<!--- What types of changes does your code introduce? Remove what does not apply. -->
- Bug fix (non-breaking change which fixes an issue)

Checklist
---------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have written unit tests.
- [] I have updated the documentation accordingly.

<!-- Place the *FULL* URL of the issue here it this PR fixes an existing issue. -->