### PR TITLE
Fix the Celery tasks and serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ api.egg-info
 api/staticfiles/
 build/
 celerybeat-schedule
+coverage.xml
 dist/
 docs/build/
 htmlcov/
+test-results/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ local-django-api: ## Run Django locally
 		&& export DJANGO_SETTINGS_MODULE=api.settings.local \
 		&& export RYR_API_API_OPTS="--reload --timeout 1800" \
 		&& export RYR_LOG_LEVEL=info \
-		&& eval $$(tools/kubernetes-django-env-vars.sh) \
+		&& eval $$(tools/kubernetes-local-env-vars.sh) \
 		&& $(LOCAL_RUN_CMD) docker/docker-entrypoint.sh api
 
 .PHONY: setup
@@ -177,6 +177,7 @@ venv/bin/activate: requirements.txt
 	test -d venv || python3 -m venv venv || virtualenv --no-setuptools --no-wheel -p python3 venv
 	. venv/bin/activate \
 		&& pip install --upgrade pip \
+		&& pip install -U -r requirements.txt \
 		&& pip install -r requirements-dev.txt \
 		&& pip install -e .
 

--- a/api/apps/api/collectors/base.py
+++ b/api/apps/api/collectors/base.py
@@ -37,6 +37,11 @@ class BusinessInfo:
         :return: A BusinessInfo with de data merged by weight, and a new weight of 0.
         :rtype: BusinessInfo
         """
+        # Do not try to merge objects of different types.
+        if not isinstance(other, BusinessInfo):
+            return self
+
+        # Merge attribute per attribute.
         merged = BusinessInfo()
         for key in self.__dict__:
             # Ignore the 'weight' property.

--- a/api/apps/api/collectors/generic.py
+++ b/api/apps/api/collectors/generic.py
@@ -62,7 +62,7 @@ class CollectorClient:
         """
         self.collector.get_place_details(place_id)
         b = self.collector.to_business_info()
-        return self.collector.to_business_info().__dict__ if b else {}
+        return b
 
     def retrieve_search_summary(self, index=0):
         """

--- a/api/apps/api/collectors/yelp.py
+++ b/api/apps/api/collectors/yelp.py
@@ -41,6 +41,8 @@ class YelpCollector(AbstractRestCollector):
 
         # Query the server.
         response = requests.get(url, headers=self.headers)
+        if response.status_code != 200:
+            response.raise_for_status()
         self.result = response.json()
 
         return self.result

--- a/api/apps/api/tests/collectors/test_base.py
+++ b/api/apps/api/tests/collectors/test_base.py
@@ -2,8 +2,9 @@
 from faker import Faker
 import pytest
 
-from api.apps.api.collectors.base import BusinessInfo
 from api.apps.api.collectors.base import AbstractCollector
+from api.apps.api.collectors.base import BusinessInfo
+from api.apps.api.collectors.base import PlaceSearchSummary
 
 
 class TestBusinessInfo:
@@ -41,11 +42,20 @@ class TestBusinessInfo:
             BusinessInfo(address='address2', weight=2),
             BusinessInfo(name='name1', address='address2'),
         ), 'Ensure objects with the less weight overwrites properties.'),
+        ((
+            BusinessInfo(name='name1', weight=3),
+            PlaceSearchSummary(),
+            BusinessInfo(name='name1', weight=3),
+        ), 'Ensure objects of different types don\'t merge'),
     ]
 
-    # Lambdas to parse the scenarios and feed the data to the test functions.
-    scenario_inputs = lambda scenarios: [test_input[0] for test_input in scenarios]
-    scenario_ids = lambda scenarios: [test_input[1] for test_input in scenarios]
+    def scenario_inputs(scenarios):
+        """Parse the scenarios and feed the data to the test function."""
+        return [test_input[0] for test_input in scenarios]
+
+    def scenario_ids(scenarios):
+        """Parse the scenarios and feed the IDs to the test function."""
+        return [test_input[1] for test_input in scenarios]
 
     def test_geolocation_00(self):
         """Ensure geolocation is computed properly for default objects."""

--- a/api/apps/api/tests/collectors/test_yelp.py
+++ b/api/apps/api/tests/collectors/test_yelp.py
@@ -43,6 +43,7 @@ class TestYelpCollector():
         """Ensure retrieve_place_details returns a dictionary."""
         yelp = YelpCollector()
         response = requests.Response()
+        response.status_code = 200
         response.json = Mock(return_value=YELP_DETAILS_RESPONSE)
         mocker.patch.object(requests, 'get', return_value=response)
         details_results = yelp.get_place_details(self.fake.pystr())
@@ -54,6 +55,7 @@ class TestYelpCollector():
         yelp = YelpCollector()
 
         response = requests.Response()
+        response.status_code = 200
         response.json = Mock(return_value=YELP_DETAILS_RESPONSE)
         mocker.patch.object(requests, 'get', return_value=response)
         yelp.get_place_details(self.fake.pystr())
@@ -73,6 +75,15 @@ class TestYelpCollector():
             weight=0)
 
         assert actual == expected
+
+    def test_retrieve_place_details_02(self, mocker):
+        """Ensure retrieve_place_details raises an exception if status is not 200."""
+        yelp = YelpCollector()
+        response = requests.Response()
+        response.status_code = 404
+        mocker.patch.object(requests, 'get', return_value=response)
+        with pytest.raises(requests.exceptions.HTTPError):
+            yelp.get_place_details(self.fake.pystr())
 
     def test_search_places_nearby_00(self):
         """Ensure the search_nearby fucntion raise `NotImplementedError`."""
@@ -267,3 +278,10 @@ YELP_DETAILS_RESPONSE_JSON = """
 }
 """
 YELP_DETAILS_RESPONSE = json.loads(YELP_DETAILS_RESPONSE_JSON)
+
+YELP_ERROR = {
+    'error': {
+        'code': 'BUSINESS_NOT_FOUND',
+        'description': 'The requested business could not be found.',
+    }
+}

--- a/api/apps/api/urls.py
+++ b/api/apps/api/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'health$', views.Health.as_view()),
     url(r'places/(?P<latlong>[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?))$',
         views.PlaceList.as_view()),
-    url(r'place/(?P<pid>.*)/$', views.PlaceDetails.as_view()),
+    url(r'place/$', views.PlaceDetails.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/api/apps/api/views.py
+++ b/api/apps/api/views.py
@@ -1,4 +1,5 @@
 """Define the API views."""
+import dataclasses
 import logging
 import os
 
@@ -52,8 +53,11 @@ class PlaceDetails(APIView):
     """View to provide detailed information about a specific place."""
 
     # pylint: disable=redefined-builtin,unused-argument
-    def get(self, request, pid, format=None):
+    def post(self, request, format=None):
         """Return the detailed information about a specific place."""
-        place_id, name, address = pid.split(',')
-        result = collect_place_details(place_id, name, address)
-        return Response(result.get())
+        result = collect_place_details(
+            request.data['place_id'],
+            request.data['name'],
+            request.data['address'],
+        )
+        return Response(dataclasses.asdict(result))

--- a/api/celery/celery_settings.py
+++ b/api/celery/celery_settings.py
@@ -9,11 +9,16 @@ from kombu.serialization import register
 logger = get_task_logger(__name__)
 
 # Register json-tricks as json encoder
-register('json_tricks.nonp', dumps, loads, content_type='application/x-json-tricks', content_encoding='utf-8')
+register(
+    'json_tricks.nonp',
+    lambda obj: dumps(obj, conv_str_byte=True),
+    lambda obj: loads(obj, conv_str_byte=True),
+    content_type='application/x-json-tricks',
+    content_encoding='utf-8',
+)
 
 # Global configuration.
-accept_content = ['application/x-json-tricks']
-accept_content = ['application/json', 'application/x-json-tricks']
+accept_content = ['application/x-json-tricks', 'application/json']
 imports = ('api.celery.tasks', )
 timezone = 'America/Chicago'
 
@@ -25,10 +30,10 @@ broker_url = os.environ.get('CELERY_BROKER_URL', 'rpc://')
 
 # Result configuration.
 result_backend = os.environ.get('CELERY_RESULT_BACKEND', 'redis://')
-result_serializer = 'json'
+result_serializer = 'json_tricks.nonp'
 
 # Task configuration.
-task_serializer = 'json'
+task_serializer = 'json_tricks.nonp'
 
 # Worker condiguration.
 worker_concurrency = 1

--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -59,10 +59,7 @@ ROOT_URLCONF = 'api.urls'
 
 # Define the site admins.
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#admins
-ADMINS = (
-    ('Rémy Greinhofer', 'remy.greinhofer@gmail.com'),
-    ('Caren V Garcia', 'carenvaleria90@gmail.com'),
-)
+ADMINS = (('Rémy Greinhofer', 'remy.greinhofer@gmail.com'), )
 
 # Define site managers.
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#managers
@@ -152,6 +149,9 @@ if os.environ.get('REDIS_URL'):
             }
         }
     }
+
+# https://docs.djangoproject.com/en/dev/ref/settings/#append-slash
+APPEND_SLASH = False
 
 # Django REST Framework.
 REST_FRAMEWORK = {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 : ${RYR_API_API_PORT:=8000}
 
 # Define Celery variables.
-: ${RYR_API_CELERY_APP:=api.celery}
+: ${RYR_API_CELERY_APP:=api.celery.worker}
 
 # Compute variables.
 DATE=$(date -u +%Y%m%dT%H%M%S%Z)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest-mock==1.10.0
 pytest-socket==0.3.1
 pytest==3.8.0
 q==2.6
+responses==0.9.0
 sphinxjp.themes.basicstrap==0.4.3
 tox==3.3.0
 wheel==0.31.1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup / Refactoring

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

The default JSON serializer is not able to serialize complex objects
like dates or dataclasses. This patch leverage json-tricks to serialize
celery data instead of the python json serializer.

* Fixes the Makefile
* Fixes the merge BusinessInfo function
* Change the place view from a GET to a POST
* Fixes the Celery tasks and their unit tests
* Uses responses for mocking HTTP requests

Motivation and Context
----------------------
<!-- Why is this change required? What problem does it solve? -->
Make Celery work again with python 3.7 (and correctly!)


How Has This Been Tested?
-------------------------
<!--
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->