### PR TITLE
Fix /place endpoint

### DIFF
--- a/api/apps/api/urls.py
+++ b/api/apps/api/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'health$', views.Health.as_view()),
     url(r'places/(?P<latlong>[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?))$',
         views.PlaceList.as_view()),
-    url(r'place/$', views.PlaceDetails.as_view()),
+    url(r'place$', views.PlaceDetails.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
Removes the trailing slash at the end of the endpoint url. 